### PR TITLE
Require _ in helpers.js

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const yaml = require('js-yaml');
 const helpers = module.exports;
 


### PR DESCRIPTION
```text
$ asyncapi-converter service.yaml
Something went wrong:
ReferenceError: _ is not defined
    at helpers.objectToSchema (/usr/local/lib/node_modules/asyncapi-converter/lib/helpers.js:66:5)
    at /usr/local/lib/node_modules/asyncapi-converter/lib/index.js:148:50
    at /usr/local/lib/node_modules/asyncapi-converter/node_modules/lodash/lodash.js:4905:15
    at baseForOwn (/usr/local/lib/node_modules/asyncapi-converter/node_modules/lodash/lodash.js:2990:24)
    at /usr/local/lib/node_modules/asyncapi-converter/node_modules/lodash/lodash.js:4874:18
    at Function.forEach (/usr/local/lib/node_modules/asyncapi-converter/node_modules/lodash/lodash.js:9342:14)
    at from2rc1to2rc2 (/usr/local/lib/node_modules/asyncapi-converter/lib/index.js:119:7)
    at from1to2rc2 (/usr/local/lib/node_modules/asyncapi-converter/lib/index.js:194:10)
    at Object.from1to2 (/usr/local/lib/node_modules/asyncapi-converter/lib/index.js:200:22)
    at Object.lib.convert (/usr/local/lib/node_modules/asyncapi-converter/lib/index.js:36:43)```